### PR TITLE
Tutorial fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ import matplotlib.pyplot as plt
 from meteostat import Point, Daily
 
 # Set time period
-start = datetime(2018, 1, 1)
-end = datetime(2018, 12, 31)
+start = '2020-01-01'
+end = '2020-12-31'
 
 # Create Point for Vancouver, BC
 vancouver = Point(49.2497, -123.1193, 70)

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ import matplotlib.pyplot as plt
 from meteostat import Point, Daily
 
 # Set time period
-start = '2020-01-01'
-end = '2020-12-31'
+start = '2018-01-01'
+end = '2018-12-31'
 
 # Create Point for Vancouver, BC
 vancouver = Point(49.2497, -123.1193, 70)


### PR DESCRIPTION
I've managed to fix the problem I described in #32 by replacing
```
start = datetime(2018, 1, 1)
end = datetime(2018, 12, 31)
```
with
```
start = '2018-01-01'
end = '2018-12-31'
```
Pandas seems to have switched from datetime comparison to String. This PR only fixed the ReadMe so you might want to fix it at other places you encounter this error.