### PR TITLE
Updating __init__.py to reflect the latest version

### DIFF
--- a/meteostat/__init__.py
+++ b/meteostat/__init__.py
@@ -12,7 +12,7 @@ The code is licensed under the MIT license.
 """
 
 __appname__ = 'meteostat'
-__version__ = '1.6.0'
+__version__ = '1.6.1'
 
 from .interface.base import Base
 from .interface.timeseries import TimeSeries


### PR DESCRIPTION
Hi there!

Great work you're doing with meteostat!
I spotted the version tag to be still `1.6.0` in the `__init__py`, so I am suggesting the following minor change:

```diff
- __version__ = '1.6.0'
+ __version__ = '1.6.1'
```

Thanks!