### PR TITLE
Replace depreciated `DataFrame.append` by `concat`

### DIFF
--- a/meteostat/interface/point.py
+++ b/meteostat/interface/point.py
@@ -105,9 +105,7 @@ class Point:
             # Remove already included stations from unfiltered
             unfiltered = unfiltered.loc[~unfiltered.index.isin(stations.index)]
             # Append to existing DataFrame
-            stations = stations.append(
-                unfiltered.head(
-                    self.max_count - selected))
+            stations = pd.concat((stations, unfiltered.head(self.max_count - selected)))
 
         # Score values
         if self.radius:


### PR DESCRIPTION
Pandas throws a warning because append is depreciated: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.append.html