### PR TITLE
Change numpy.NaN to numpy.nan for compatibility with numpy>=2.0.0

### DIFF
--- a/meteostat/interface/normals.py
+++ b/meteostat/interface/normals.py
@@ -163,8 +163,8 @@ class Normals(MeteoData):
                     else df
                 )
 
-        # None -> NaN
-        temp._data = temp._data.fillna(np.NaN)
+        # None -> nan
+        temp._data = temp._data.fillna(np.nan)
 
         # Return class instance
         return temp

--- a/meteostat/interface/timeseries.py
+++ b/meteostat/interface/timeseries.py
@@ -123,7 +123,7 @@ class TimeSeries(MeteoData):
                 (pd.isna(self._data[f"{col_name}_flag"]))
                 | (self._data[f"{col_name}_flag"].str.contains(self._model_flag)),
                 col_name,
-            ] = np.NaN
+            ] = np.nan
 
         # Conditionally, remove flags from DataFrame
         if not self._flags:
@@ -131,7 +131,7 @@ class TimeSeries(MeteoData):
                 map(lambda col_name: f"{col_name}_flag", columns), axis=1, inplace=True
             )
 
-        # Drop NaN-only rows
+        # Drop nan-only rows
         self._data.dropna(how="all", subset=columns, inplace=True)
 
     def _init_time_series(

--- a/meteostat/series/normalize.py
+++ b/meteostat/series/normalize.py
@@ -9,7 +9,7 @@ The code is licensed under the MIT license.
 """
 
 from copy import copy
-from numpy import NaN
+from numpy import nan
 import pandas as pd
 import pytz
 from meteostat.core.warn import warn
@@ -56,7 +56,7 @@ def normalize(self):
             # Add columns
             for column in temp._columns[temp._first_met_col :]:
                 # Add column to DataFrame
-                df[column] = NaN
+                df[column] = nan
 
             result = pd.concat([result, df], axis=0)
 
@@ -70,8 +70,8 @@ def normalize(self):
             .first()
         )
 
-        # None -> NaN
-        temp._data = temp._data.fillna(NaN)
+        # None -> nan
+        temp._data = temp._data.fillna(nan)
 
     # Return class instance
     return temp

--- a/meteostat/units.py
+++ b/meteostat/units.py
@@ -6,7 +6,7 @@ Convert a Pandas Series to any meteorological data unit
 The code is licensed under the MIT license.
 """
 
-from numpy import NaN, isnan
+from numpy import nan, isnan
 
 
 def fahrenheit(value):
@@ -62,7 +62,7 @@ def direction(value):
     Convert degrees to wind direction
     """
 
-    wdir = NaN
+    wdir = nan
 
     if (337 <= value <= 360) or value <= 23:
         wdir = "N"
@@ -90,7 +90,7 @@ def condition(value):
     """
 
     if isnan(value) or value < 1 or value > 27:
-        return NaN
+        return nan
 
     return [
         "Clear",

--- a/meteostat/utilities/aggregations.py
+++ b/meteostat/utilities/aggregations.py
@@ -19,7 +19,7 @@ def weighted_average(step: pd.DataFrame) -> pd.DataFrame:
 
     data = np.ma.masked_array(step, np.isnan(step))
     data = np.ma.average(data, axis=0, weights=data[:, -2])
-    data = data.filled(np.NaN)
+    data = data.filled(np.nan)
 
     return pd.DataFrame(data=[data], columns=step.columns)
 
@@ -30,7 +30,7 @@ def degree_mean(data: pd.Series) -> float:
     """
 
     if data.isnull().all():
-        return np.NaN
+        return np.nan
 
     rads = np.deg2rad(data)
     sums = np.arctan2(np.sum(np.sin(rads)), np.sum(np.cos(rads)))

--- a/meteostat/utilities/mutations.py
+++ b/meteostat/utilities/mutations.py
@@ -52,7 +52,7 @@ def adjust_temp(df: pd.DataFrame, alt: int):
     # Adjust values for all temperature-like data
     for col_name in temp_like:
         if col_name in df.columns:
-            df.loc[df[col_name] != np.NaN, col_name] = df[col_name] + (
+            df.loc[df[col_name] != np.nan, col_name] = df[col_name] + (
                 temp_diff * ((df["elevation"] - alt) / 100)
             )
 


### PR DESCRIPTION
Starting from numpy `2.0.0` the `NaN` import is missing:
https://github.com/numpy/numpy/blob/v2.0.0/numpy/__init__.pyi
The doc also recommends switching to `nan`:
https://numpy.org/doc/stable/reference/constants.html#numpy.NAN